### PR TITLE
Upgrade the skill repository to a marketplace for intuitive visual management of skills in CC.

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,0 +1,42 @@
+{
+  "name": "agent-skills",
+  "owner": {
+    "name": "Zhenyu Zheng",
+    "email": "zheng.zhenyu@outlook.com"
+  },
+  "metadata": {
+    "description": "Ascend Agent's custom skills for NPU development and more",
+    "version": "1.0.0"
+  },
+  "plugins": [
+    {
+      "name": "agent-skills-infrastructure",
+      "description": "Infrastructure team skills.",
+      "source": "./",
+      "strict": false,
+      "skills": [
+        "./skills/infrastructure/docker-image-pr-fix",
+        "./skills/infrastructure/github-action-diagnose"
+      ]
+    },
+    {
+      "name": "agent-skills-operation",
+      "description": "Operation team skills.",
+      "source": "./",
+      "strict": false,
+      "skills": [
+        "./skills/operation/content/release-vllm-reno-poster"
+      ]
+    },
+    {
+      "name": "agent-skills-upstream",
+      "description": "Upstream team skills.",
+      "source": "./",
+      "strict": false,
+      "skills": [
+        "./skills/upstream/triton-upgrade",
+        "./skills/upstream/vllm-ascend-releasing-note"
+      ]
+    }
+  ]
+}

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,5 +1,5 @@
 {
-  "name": "agent-skills",
+  "name": "opensourceways-agent-skills",
   "owner": {
     "name": "Zhenyu Zheng",
     "email": "zheng.zhenyu@outlook.com"

--- a/README.md
+++ b/README.md
@@ -79,14 +79,14 @@ git push origin feature/add-new-skill
 
    在 Claude Code 中输入 `/plugin` 或点击插件图标，然后：
    - 选择 `Browse and install plugins`（浏览并安装插件）
-   - 选择 `agent-skills` marketplace
+  - 选择 `opensourceways-agent-skills` marketplace
    - 选择你想要安装的技能（例如 `triton-upgrade`）
    - 点击 `Install now`（立即安装）
 
    **方式 B：命令行直接安装**
 
    ```
-   /plugin install triton-upgrade@agent-skills
+  /plugin install triton-upgrade@opensourceways-agent-skills
    ```
 
 
@@ -100,12 +100,12 @@ git push origin feature/add-new-skill
 
    ```json
    {
-     "ascend-agent-skills": {
+     "opensourceways-agent-skills": {
        "source": {
          "source": "github",
          "repo": "opensourceways/agent-skills"
        },
-       "installLocation": "~/.claude/plugins/marketplaces/agent-skills",
+       "installLocation": "~/.claude/plugins/marketplaces/opensourceways-agent-skills",
        "lastUpdated": "2026-02-13T00:00:00.000Z"
      }
    }
@@ -118,7 +118,7 @@ git push origin feature/add-new-skill
    在终端中运行安装命令：
 
    ```bash
-   claude plugin install triton-upgrade@agent-skills
+  claude plugin install triton-upgrade@opensourceways-agent-skills
    ```
 
 

--- a/README.md
+++ b/README.md
@@ -57,9 +57,72 @@ git push origin feature/add-new-skill
 
 #### 在 Claude Code 中配置
 
-有两种方式使用仓库中的 skills：
+本指南将帮助你将此 marketplace 中的技能安装到你自己的 Claude Code 环境中。
 
-##### 方式一：本地克隆使用
+##### 方法一：在 Claude Code 客户端中添加（推荐）
+
+你可以在 Claude Code 客户端中直接添加此 marketplace 并安装技能。
+
+1. **添加 Marketplace**
+
+   在 Claude Code 中运行以下命令：
+
+   ```
+   /plugin marketplace add opensourceways/agent-skills
+   ```
+
+2. **浏览并安装skill**
+
+   添加 marketplace 后，你可以通过以下两种方式安装技能：
+
+   **方式 A：交互式安装**
+
+   在 Claude Code 中输入 `/plugin` 或点击插件图标，然后：
+   - 选择 `Browse and install plugins`（浏览并安装插件）
+   - 选择 `agent-skills` marketplace
+   - 选择你想要安装的技能（例如 `triton-upgrade`）
+   - 点击 `Install now`（立即安装）
+
+   **方式 B：命令行直接安装**
+
+   ```
+   /plugin install triton-upgrade@agent-skills
+   ```
+
+
+##### 方法二：手动编辑配置文件
+
+如果你更喜欢手动配置，可以按照以下步骤操作：
+
+1. **编辑 known_marketplaces.json**
+
+   打开或创建 `~/.claude/plugins/known_marketplaces.json` 文件，添加以下内容：
+
+   ```json
+   {
+     "ascend-agent-skills": {
+       "source": {
+         "source": "github",
+         "repo": "opensourceways/agent-skills"
+       },
+       "installLocation": "~/.claude/plugins/marketplaces/agent-skills",
+       "lastUpdated": "2026-02-13T00:00:00.000Z"
+     }
+   }
+   ```
+
+   > **注意**：如果你的 `known_marketplaces.json` 文件中已经有其他 marketplace，请确保添加逗号并保持 JSON 格式正确。
+
+2. **安装skill**
+
+   在终端中运行安装命令：
+
+   ```bash
+   claude plugin install triton-upgrade@agent-skills
+   ```
+
+
+##### 方式三：本地克隆使用
 
 ```bash
 # 1. 克隆仓库到本地
@@ -79,7 +142,7 @@ git clone <repository-url> ~/agent-skills
 # 3. 重启 Claude Code 或重新加载配置
 ```
 
-##### 方式二：直接引用 GitHub 上的 Skills
+##### 方式四：直接引用 GitHub 上的 Skills
 
 ```bash
 # 在 Claude Code 配置中使用 Git URL


### PR DESCRIPTION
## 描述
将skill仓库升级为marketplace，方便在cc中可视化管理skill

修改点：
1、新增了marketplace配置文件，现在可以在cc中的manage plugin功能中管理仓库中的plugin和skill
2、修改readme，添加两种使用skill的方法，可以在cc cli中通过命令引入skill

效果：
<img width="611" height="741" alt="image" src="https://github.com/user-attachments/assets/f676e94e-5cef-4142-957a-d54da19b2760" />
<img width="581" height="564" alt="image" src="https://github.com/user-attachments/assets/73106602-2ff9-4892-9f55-bf530ef9d461" />
<img width="583" height="1201" alt="image" src="https://github.com/user-attachments/assets/b1fc8f03-5055-42aa-977f-875184177388" />
<img width="1450" height="935" alt="image" src="https://github.com/user-attachments/assets/5cc79718-2ea6-4383-8078-36942d78eccf" />
