### PR TITLE
Add github action diagnosing skill for ascend CI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@
 
 # Claude Code settings
 .claude/
+.omc/
 
 # Temporary files
 *.tmp

--- a/skills/infrastructure/README.md
+++ b/skills/infrastructure/README.md
@@ -28,7 +28,7 @@ infrastructure/
 
 <!-- 在此列出你的 skills，保持更新 -->
 
-- 暂无
+- **Github-action-diagnose**: 诊断昇腾CI github action问题
 
 ## 团队规范
 

--- a/skills/infrastructure/README.md
+++ b/skills/infrastructure/README.md
@@ -28,7 +28,77 @@ infrastructure/
 
 <!-- 在此列出你的 skills，保持更新 -->
 
-- **Github-action-diagnose**: 诊断昇腾CI github action问题
+| 名字 | 功能 |
+| --- | --- |
+| Github-action-diagnose | 诊断昇腾CI github action问题 |
+
+### Github-action-diagnose
+
+#### 使用示例
+
+**示例 1：通过 GitHub Actions Run URL 诊断**
+
+```
+/github-action-diagnose https://github.com/my-org/my-repo/actions/runs/12345678901
+```
+
+技能会自动：
+1. 提取 `owner/repo` = `my-org/my-repo`，`run_id` = `12345678901`
+2. 执行 `gh run view 12345678901 --repo my-org/my-repo --log-failed`
+3. 进入 5 步诊断流程
+
+---
+
+**示例 2：通过 Run ID 诊断（在 repo 目录下）**
+
+```
+/github-action-diagnose 12345678901
+```
+
+技能会从当前目录推断 repo，然后执行诊断。
+
+---
+
+**示例 3：直接粘贴日志内容**
+
+```
+/github-action-diagnose
+2024-01-15T10:23:45.123Z [error] npu-smi info: ERR99999 Device not found
+2024-01-15T10:23:45.456Z [error] error code 507035
+2024-01-15T10:23:46.000Z Process exited with code 1
+```
+
+---
+
+**示例输出 A：基础设施故障**
+
+```
+# GitHub Action 故障诊断报告
+
+## 1. 故障概览
+- **任务名称**: train-resnet50
+- **Run ID**: 12345678901
+- **故障定性**: 硬件故障
+- **判定依据**: NPU 驱动报 ERR99999，Device not found
+
+## 2. 详细诊断
+- **失败步骤**: Run steps (pytest)
+- **报错原文**: `npu-smi info: ERR99999 error code 507035`
+- **物理节点**: a3-runner-0023 -> Pod a3-0/runner-abc -> node-a3-12
+- **根因分析**: 物理机 node-a3-12 上 NPU 设备驱动异常，设备不可用
+```
+
+---
+
+**示例输出 B：非基础设施问题**
+
+```
+未发现环境/基础设施故障。
+
+分析依据：调度正常（Set up job 完成）、镜像拉取成功、NPU 挂载无报错。
+失败发生在业务代码层：Python Traceback 指向 tests/test_model.py:42，
+AssertionError: expected accuracy > 0.8, got 0.75。
+```
 
 ## 团队规范
 

--- a/skills/infrastructure/github-action-diagnose/SKILL.md
+++ b/skills/infrastructure/github-action-diagnose/SKILL.md
@@ -1,51 +1,99 @@
 ---
-name: gha-ascend-infra-detect
-description: Automated diagnostic agent for GitHub Action failures on Ascend NPU infrastructure. Analyzes GHA logs, searches repository for similar issues, and performs deep K8s/Node-level troubleshooting for self-hosted runners (ARC). Use when a GHA job fails on Ascend hardware and infrastructure issues (Saturation, Hardware fault, K8s scheduling) are suspected.
+name: github-action-diagnose
+description: 诊断昇腾（Ascend）NPU 集群上 GitHub Actions 执行失败的原因，定位基础设施故障与根因分析
+allowed-tools: Bash(gh run view:*), Bash(gh run list:*), Bash(gh api:*), Bash(kubectl get:*), Bash(kubectl describe:*), Bash(kubectl logs:*), Bash(kubectl config:*), Read, Grep
 ---
 
-# GHA Ascend Infrastructure Detective
+## Your task
 
-This skill embodies a systematic approach to diagnosing CI failures in specialized hardware environments (Ascend NPU) using SRE principles like the USE Method (Utilization, Saturation, Errors).
+诊断昇腾（Ascend）NPU 集群上 GitHub Actions 的执行失败。仅做故障定性和根因分析，不提供修复建议。
+所有只读操作（gh CLI、kubectl 查询、日志读取）直接执行，无需用户确认。
 
-## Core Diagnostic Workflow
+本技能采用 5 步诊断流程：Step 0 输入识别 + 4 步诊断逻辑（生命周期分诊 → 物理节点溯源与环境故障定位 → 非环境问题判定 → 输出报告）。
 
-### 1. Initial GHA Log Analysis
-Analyze the failed GitHub Action log to differentiate between code bugs and infrastructure issues.
-- **Signs of Code Bug**: Python `Traceback`, `AssertionError`, `FileNotFoundError` (within workspace).
-- **Signs of Infra Issue**: `Runner connection lost`, `Process completed with exit code 255/137`, `Context canceled`, `Failed to initialize NPU`.
+### Step 0: 识别输入并获取日志
 
-**Action**: Use `gh issue list --search "[error message]"` to check if this is a known intermittent issue or environmental flake.
+分析用户提供的输入，自动识别类型：
 
-### 2. K8s Level (ARC) Diagnostics
-If infra is suspected, check the status of the `EphemeralRunner` and its underlying Pod.
-- **Pod Scheduling**: Look for `Pending` state. Use `kubectl describe pod <pod-name>` to check for:
-    - `Insufficient huawei.com/ascend-910`: Resource saturation.
-    - `0/N nodes are available: ... pod has unbound immediate PersistentVolumeClaims`: Storage issue.
-- **Pod Lifecycle**: Check for `OOMKilled` (137) or `Evicted`.
+- **GitHub Actions Run URL**（包含 `/actions/runs/`）：提取 owner/repo 和 run_id，执行 `gh run view <run_id> --repo <owner/repo> --log-failed` 获取失败日志。
+- **Run ID**（纯数字）：需要用户确认 repo 或从当前目录推断，然后执行 `gh run view <run_id> --log-failed`。
+- **粘贴的日志内容**（非 URL 非纯数字）：直接作为日志内容进行分析。
 
-### 3. Node & Hardware Deep Dive (Ascend NPU)
-When cluster-level status is healthy but jobs fail, perform hardware-level checks. **Requires User Consent for SSH/Exec.**
+如果 `--log-failed` 信息不足，自动尝试 `gh run view <run_id> --log` 获取完整日志。
+同时获取 run 的元信息：`gh run view <run_id> --repo <owner/repo> --json jobs,name,status,conclusion,headBranch,event`。
 
-- **NPU Health Check**: Run `npu-smi info` on the target node.
-    - **Health Status**: Anything other than "OK" indicates hardware/driver fault.
-    - **Utilization/Saturation**: Check `HBM Used` and `NPU Usage`.
-- **System Logs**: Search for driver/firmware signals.
-    - `dmesg | grep -iE "hiai|npu"`: Look for PCIE errors, heartbeat loss, or firmware crashes.
+### Step 1: 生命周期分诊
 
-## Actionable Principles (USE Method)
+根据失败发生的步骤进行初步分类：
 
-- **Utilization**: Check if NPUs are fully utilized across the cluster.
-- **Saturation**: Check for "Queueing" signals (Pending pods, high load average on nodes).
-- **Errors**: Check for hardware alarms, driver crashes, and communication timeouts.
+| 失败步骤 | 初步定性 | 说明 |
+|----------|---------|------|
+| Set up job | 环境问题 | Runner 无法拉起/调度失败 |
+| Initialize containers | 环境问题 | 容器运行时异常/镜像拉取失败 |
+| Checkout / Setup Environment | 环境问题 | 网络/挂载/权限故障 |
+| Run steps（pytest/lint 等） | 需进一步分析 | Runner 已就绪，进入 Step 2-3 细分 |
 
-## User Interaction Guidelines
+如果失败在前三类步骤，直接标记为环境问题并进入 Step 2。
+如果失败在 Run steps，需要同时执行 Step 2 和 Step 3 来区分环境故障与代码问题。
 
-- **Consent First**: Always ask before executing `kubectl exec`, `ssh`, or any command that interacts with the live environment.
-- **Mode A (Autonomous)**: Aim to gather all evidence automatically but explain each step clearly to the user.
-- **Final Opinion**: Synthesize all findings (GHA log + Issue search + K8s status + Node health) into a clear "Infrastructure Health Report" with a definitive conclusion (e.g., "Hardware Fault: Node-02 NPU Memory Error").
+### Step 2: 物理节点溯源 + 环境故障深度定位
 
-## Test Scenarios for Validation
+#### 2a. 物理节点溯源
+当判定为环境故障或怀疑硬件问题时，定位物理节点：
 
-1. **Scenario: Resource Queuing** - Pod is Pending due to NPU exhaustion. Skill should identify "Unschedulable" status and report saturation.
-2. **Scenario: NPU Heartbeat Loss** - Job fails with connection lost. Skill should find "Heartbeat loss" in node dmesg and conclude hardware fault.
-3. **Scenario: Known Flake** - Job fails with a specific error string found in 3 open issues. Skill should link issues and conclude "Known Intermittent Flake".
+1. 从 `Set up job` 日志或 `gh api` 获取 `runner_name`（即 Pod 名称）。
+2. 从 `runner_name` 前缀或 Job Labels 识别节点池（如 `a3-0`）。
+3. 自动发现 namespace：`kubectl get pods --all-namespaces --no-headers | grep <runner_name>` 提取 namespace。
+4. 反查物理机：
+   - Pod 未销毁：`kubectl get pod <runner_name> -n <namespace> -o custom-columns=NODE:.spec.nodeName --no-headers`
+   - Pod 已销毁：在日志中搜索 `Successfully assigned <runner_name> to <node_name>`。
+
+#### 2b. 环境故障深度定位
+检查以下故障模式：
+
+- **驱动/硬件失效**：`npu-smi info` 报错、`ERR99999`、`error code 507035`、`Device not found`。
+- **资源溢出 (OOM)**：系统级 `Killed` 信号、`Bus error`（SHM 不足）、`No space left on device`。
+- **多机连锁超时**：多机任务中某节点报 `Timeout`，优先识别并检查 Master 节点。Master 节点识别方法：
+  - 检查 `RANK_TABLE_FILE` 中 `rank_id=0` 对应的节点
+  - 或在日志中搜索 `master_addr` / `MASTER_ADDR` 环境变量指向的节点
+  - 确认 Master 节点是否有 `Unexpected Exit` 或驱动报错
+
+### Step 3: 非环境问题判定
+
+如果 Step 2 未发现环境/硬件故障，检查以下非环境因素：
+
+- **YAML 语法错误**：如 `undefined variable "False"`（应为小写 `false`）。
+- **业务逻辑报错**：`AssertionError`、Python Traceback 指向业务源码、测试用例失败。
+- **依赖问题**：pip/npm 安装失败但非网络原因（版本冲突、包不存在）。
+
+### Step 4: 输出诊断报告
+
+根据诊断结果选择输出模式：
+
+#### 情况 A：确认为基础设施/硬件故障
+
+严格按照以下格式输出：
+
+```
+# GitHub Action 故障诊断报告
+
+## 1. 故障概览
+- **任务名称**: [Job Name]
+- **Run ID**: [Run ID]
+- **故障定性**: 环境问题 / 硬件故障 / 集群调度异常
+- **判定依据**: [驱动报错/调度异常/硬件死锁/OOM 等]
+
+## 2. 详细诊断
+- **失败步骤**: [Set up job / Initialize containers / Run steps 等]
+- **报错原文**: [引用关键日志片段]
+- **物理节点**: [Runner 名] -> [Pod] -> [物理机/节点池]
+- **根因分析**: [深层原因说明]
+```
+
+#### 情况 B：环境正常，非基础设施问题
+
+采用自然语言简要反馈：
+1. **结论**：直接告知"未发现环境/基础设施故障"。
+2. **依据**：简述分析了哪些环节（调度、镜像拉取、NPU 挂载等均正常）。
+
+注意：两种情况均不输出修复建议或操作手册。

--- a/skills/infrastructure/github-action-diagnose/evals/evals.json
+++ b/skills/infrastructure/github-action-diagnose/evals/evals.json
@@ -1,0 +1,53 @@
+{
+  "skill_name": "github-action-diagnose",
+  "evals": [
+    {
+      "id": 1,
+      "prompt": "https://github.com/tile-ai/tilelang-ascend/actions/runs/22718535502",
+      "expected_output": "识别为基础设施故障：镜像拉取失败（image pull failure），输出结构化诊断报告",
+      "files": [],
+      "assertions": [
+        {
+          "name": "输出结构化报告（情况A格式）",
+          "description": "输出包含 '# GitHub Action 故障诊断报告' 标题，说明技能正确识别为基础设施故障并使用了规定格式"
+        },
+        {
+          "name": "识别为镜像拉取失败",
+          "description": "输出中包含 '镜像' 或 'image pull' 或 'pull' 相关关键词，说明技能正确定性了故障类型"
+        },
+        {
+          "name": "包含故障定性字段",
+          "description": "输出包含 '故障定性' 字段，符合规定的报告结构"
+        },
+        {
+          "name": "不包含修复建议",
+          "description": "输出不包含 '建议' 或 '修复' 或 '解决方案' 等字样，符合技能只做诊断不提供修复建议的要求"
+        }
+      ]
+    },
+    {
+      "id": 2,
+      "prompt": "https://github.com/sgl-project/sglang/actions/runs/22573924024/job/65388415192",
+      "expected_output": "识别为基础设施故障：网络问题，输出结构化诊断报告",
+      "files": [],
+      "assertions": [
+        {
+          "name": "输出结构化报告（情况A格式）",
+          "description": "输出包含 '# GitHub Action 故障诊断报告' 标题，说明技能正确识别为基础设施故障并使用了规定格式"
+        },
+        {
+          "name": "识别为网络问题",
+          "description": "输出中包含 '网络' 或 'network' 或 'timeout' 或 'connection' 相关关键词，说明技能正确定性了故障类型"
+        },
+        {
+          "name": "包含故障定性字段",
+          "description": "输出包含 '故障定性' 字段，符合规定的报告结构"
+        },
+        {
+          "name": "不包含修复建议",
+          "description": "输出不包含 '建议' 或 '修复' 或 '解决方案' 等字样，符合技能只做诊断不提供修复建议的要求"
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## 描述

更新用于诊断昇腾（Ascend）NPU 集群上 GitHub Actions 执行失败的 skill。

### 主要变更

- **重命名 skill**：`gha-ascend-infra-detect` → `github-action-diagnose`，名称更直观
- **重写诊断流程**：采用结构化 5 步诊断逻辑：
  - **Step 0**：识别输入类型（Run URL / Run ID / 粘贴日志），自动获取日志
  - **Step 1**：生命周期分诊（Set up job / Initialize containers / Run steps）
  - **Step 2**：物理节点溯源 + 环境故障深度定位（驱动/硬件失效、OOM、多机连锁超时）
  - **Step 3**：非环境问题判定（YAML 语法错误、业务逻辑报错、依赖问题）
  - **Step 4**：输出诊断报告（基础设施故障输出结构化报告；环境正常则自然语言简要反馈）
- **新增 evals**：添加 `evals/evals.json`，包含 2 个测试用例（镜像拉取失败、网络问题），验证 skill 的诊断能力和报告格式
- **更新 README**：在 infrastructure 技能列表中注册新 skill

## 相关 Issue

无

## 变更类型

- [ ] Bug 修复
- [ ] 新功能
- [x] 代码重构
- [ ] 文档更新
- [ ] 样式改进
- [ ] 性能优化
- [ ] 测试相关
- [ ] 其他